### PR TITLE
fix: bug 2 and bug 3

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -22,7 +22,10 @@ def write_received_book(book_id, shared_list):
         with open(filename, 'w', encoding='utf-8') as f:
             node = head
             while node:
-                f.write(node.line + '\n')
+                # 根据你 split 时的逻辑，last line 不需要添加换行符
+                if node.book_next:
+                    node.line += '\n'
+                f.write(node.line)
                 node = node.book_next
         print(f"Book {book_id} written to {filename}")
     except Exception as e:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,6 +19,13 @@ echo "Starting server on $SERVER_HOST:$SERVER_PORT with pattern \"$PATTERN\"..."
 ./assignment3.py -l $SERVER_PORT -p "$PATTERN" &
 SERVER_PID=$!
 
+stop() {
+    echo "--- stop ---"
+    kill -9 $SERVER_PID
+}
+# 监听 SIGTERM 和 SIGINT 信号
+trap stop SIGINT SIGTERM
+
 sleep 2
 
 TEXT_FILES=(
@@ -61,6 +68,5 @@ done
 wait
 
 echo "Stopping server..."
-kill $SERVER_PID
 
 echo "Test completed."


### PR DESCRIPTION
2. 运行test.sh后，pattern analysis的结果会一直打印在屏幕上，用ctrl+c无法结束。这可能是因为server.py中的start_analysis_threads()创建的都是daemon threads，且主程序在无限循环，也因此测试脚本跑不到最后stop_server的地方。预期是ctrl+c可以结束进程，或者在全部分析结束后的一段时间可以结束进程。但我不知道咋改……

	监听退出时的信号，退出时执行对应的函数，注意，提前将其将其监听

	````bash
	stop() {
	    echo "--- stop ---"
	    kill -9 $SERVER_PID
	}
	# 监听 SIGTERM 和 SIGINT 信号
	trap stop SIGINT SIGTERM
	# 注意将这段放在脚本最前面，要不然 没加载，不生效，相当于一个注册函数
	````

3. 任务要求是把从链表中把每本书的每一行都写入新的txt文件，也就是说生成的文件和源文件的内容应该是完全一样的，但我发现当前代码无法写入最后一行。这可能是因为client_handle.py里的process_buffer()在处理数据的时候以换行符来分割每一行，于是没有换行符的最后一行就被漏掉了。但我尝试fix这个问题的时候，越弄越乱……。

	逻辑存在问题：

	1. 文件写入内容时，在根据文件流拆分规则，last line 行尾不需要添加换行符，因为是以行尾换行符进行 split 的 
	2. 未考虑断点续接的功能
	3. 文件处理时，未将文件结尾考虑进去
	4. 其实还有很多很多的问题，当前这个文档做 demo 可以，正式一点的就不行了
		1. 目前文档的字符基本都是 ascii 几乎没有问题，但是如果出现 unicode 或者其他的复杂码集 数据，就会出现切割问题
		2. 在不同设备上，不兼容，mac8 之前的换行是 \r， windows 时 \r\n
		3. .... 
